### PR TITLE
Changeset import: Performance improvements via bulk insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Then use bundler to install the gems and start the import
     $ ./osmchanges.rb setup -d <databasename>
     $ ./osmchanges.rb import -d <databasename> -f /path/to/changesets-latest.osm  # this will take a while
 
+  This performance branch uses bulk inserts to speed up processing by roughly a factor of 10. At the same time no checks for already existing entries in table changes will be executed anymore. Be sure to start with empty tables otherwise duplicate entries might occur. Package processing can be controlled by specifying a package size via parameter '-s'. As a default setting a package size of 5000 changesets will be assumed. This should be a reasonable default for most situations.
+
   Now you will need to find a sequence number that will work for the time you did the import. A safe bet is to look at the date on the changesets-latest.osm file you downloaded and go back half a day or so. Start [here](http://planet.osm.org/replication/changesets/000/) and drill all the way down to a specific file. You don't need to download the file, you just need to get the number. You will need the full sequence number. e.g. The sequence number for http://planet.osm.org/replication/changesets/000/020/999.osm.gz is 000020999. You will use this sequence number for the next command so the importer knows how to "catch up" and bootstrap the diff process. I would like to improve this, but since you only need to do this once, it's not a huge deal for now.
 
     $ ./osmchanges.rb sync -s 000020999  # use your sequence number

--- a/osmchanges.rb
+++ b/osmchanges.rb
@@ -32,13 +32,13 @@ class OsmChanges < Thor
     previous_time = Time.now
     throughput = 0
     total_changesets = 0
-    package_size = Integer(options[:pkgsize]) || 5000
+    package_size = Integer(options[:pkgsize] || 5000)
     parse_changesets(File.open(options[:file])) do |changeset|
       tmp_changesets << changeset
       if tmp_changesets.count == package_size
         total_changesets = total_changesets + package_size
         current_time = Time.now
-        throughput = package_size / ( current_time - previous_time ).to_f
+        throughput = package_size / ( current_time - previous_time ).to_f rescue 0
         previous_time = current_time
         printf "Inserting %d changesets (total %d), %.0f changesets/s\n", package_size, total_changesets, throughput
         insert_changesets (tmp_changesets)
@@ -46,10 +46,12 @@ class OsmChanges < Thor
       end
     end
     if tmp_changesets.count > 0
-      puts "Inserting remaining #{changesets.count} changesets"
+      total_changesets = total_changesets + tmp_changesets.count
+      printf "Inserting %d changesets (total %d)\n", tmp_changesets.count, total_changesets
       insert_changesets (tmp_changesets)
       tmp_changesets.clear
     end
+    puts "Import completed."
   end
 
   desc "sync", "Sync changesets from planet.osm.org"


### PR DESCRIPTION
Processing about 21 mio changesets one by one seemed to take quite a lot of time. In this pull request I've included a solution to create packages of up to 5000 changesets (configurable parameter) and insert them at once. This way import times went down to 3-4 hours on my machine. See README.md changes for more details.

Please review carefully before applying as I'm really a Ruby n00b. Code is probably not ruby idiomatic, feel free to adjust as needed.
